### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/loveisweird/4c62e129-0159-4096-ad07-d1fe7c3207b6/c318850e-cbb2-47ef-823c-415723c5bde2/_apis/work/boardbadge/b4121902-8bf5-496c-a19b-10442106360b)](https://dev.azure.com/loveisweird/4c62e129-0159-4096-ad07-d1fe7c3207b6/_boards/board/t/c318850e-cbb2-47ef-823c-415723c5bde2/Microsoft.RequirementCategory)
 # stackblitz-webcontainer-api-starter-jhedpb
 
 [Edit on StackBlitz ⚡️](https://stackblitz.com/edit/stackblitz-webcontainer-api-starter-jhedpb)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/loveisweird/4c62e129-0159-4096-ad07-d1fe7c3207b6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.